### PR TITLE
fix: converge jakarta.activation-api to 2.1.4 (fix enforcer build break)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,14 @@
         <artifactId>jaxb-impl</artifactId>
         <version>4.0.9</version>
       </dependency>
+      <!-- Converge jakarta.activation-api: jakarta.xml.bind-api:4.0.1 pulls 2.1.2 while
+           jaxb-impl:4.0.9 (via angus-activation) pulls 2.1.4, tripping the enforcer
+           DependencyConvergence rule. Pin the higher to force a single version. -->
+      <dependency>
+        <groupId>jakarta.activation</groupId>
+        <artifactId>jakarta.activation-api</artifactId>
+        <version>2.1.4</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
## Problem
`main` fails the Maven `enforcer:DependencyConvergence` rule → build broken (Jenkins red) since the `jaxb-impl` 4.0.9 bump (#66, merged 2026-07-11):

```
Dependency convergence error for jakarta.activation:jakarta.activation-api:jar:2.1.2 paths are:
  jakarta.xml.bind:jakarta.xml.bind-api:4.0.1 -> jakarta.activation-api:2.1.2
  com.sun.xml.bind:jaxb-impl:4.0.9 -> jaxb-core -> org.eclipse.angus:angus-activation:2.0.3 -> jakarta.activation-api:2.1.4
```

## Fix
Pin `jakarta.activation:jakarta.activation-api` to **2.1.4** (the higher) in the parent `<dependencyManagement>`, forcing a single resolution across both paths.

## Verified
`./mvnw -DskipTests package` → BUILD SUCCESS, enforcer passes. One-line dependency-management pin; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)